### PR TITLE
Bugfix footer: background-image width and height

### DIFF
--- a/src/sass/components/_footer.scss
+++ b/src/sass/components/_footer.scss
@@ -1,31 +1,24 @@
 .footer {
-    min-height: 619px;
-    height: auto;
-    min-width: 320px;
-    width: 100%;
+    max-height: 619px;
+    max-width: 100%;
 
     @media screen and (min-width: $tablet) {
-        min-height: 506px;
-       height: auto;
-       min-width: 768px;
-       width: 100%;
+        max-height: 506px;
     }
 
     @media screen and (min-width: $desktop) {
-        min-height: 395px;
-        height: auto;
-        min-width: 1200px;
-        width: 100%;
+        max-height: 395px;
     }
 }
 
 .footer-container {
     padding-top: 60px;
     padding-bottom: 60px;
+    height: 619px;
     background-image: url(../images/mobile/footer-mobile-background.png);
     background-repeat: no-repeat;
-    background-position: center;
-    background-size: cover;
+    background-position: bottom;
+    background-size: 100% 100%;
 
     @include retina {
         background-image: url(../images/mobile/footer-mobile-background@2x.png);
@@ -35,6 +28,7 @@
     @media screen and (min-width: $tablet) {
         padding-top: 100px;
         padding-bottom: 100px;
+        height: 506px;
         background-image: url(../images/tablet/footer-background-tab.png);
 
         @include retina {
@@ -45,6 +39,7 @@
 
     @media screen and (min-width: $desktop) {
         padding-bottom: 100px;
+        height: 395px;
         background-image: url(../images/desktop/footer-background-desk.png);
         background-size: contain;
 


### PR DESCRIPTION
### Reviewers 

- [ ] @Khavkin 

- [ ]  @lumpy-the-moose 

---
### Summary of Issue

During changing of viewport the width and height of background-images were not suitable so that the top and bottom of background images were out of sight.

---

### Summary of Change

Fixed width and height of background images for mobile, tablet and desktop viewports.

---

### Done 

Changed background-size to 100% 100% and background-position to bottom. Now background images don't change in tablet and desktop viewport. In mobile viewport image is stretching, but the content of the image is stretching as well (screenshot below).


<img width="292" alt="Screenshot 2022-11-01 at 15 39 46" src="https://user-images.githubusercontent.com/111194179/199260296-014acd54-c56c-43a9-a8bc-e43efde170d8.png">

---

### TODO

Change the way background image is displayed in mobile viewport.
